### PR TITLE
Update links for GitHub org rename

### DIFF
--- a/backend.md
+++ b/backend.md
@@ -1,7 +1,7 @@
 
 ## Backend and Full-Stack Exercise
 
-Copyright 2016, Fauna, Inc. All rights reserved. For general instructions, see [here](https://github.com/faunadb/exercises/blob/master/README.md).
+Copyright 2016, Fauna, Inc. All rights reserved. For general instructions, see [here](https://github.com/fauna/exercises/blob/master/README.md).
 
 ### RESTful API Service
 

--- a/visualization.md
+++ b/visualization.md
@@ -1,15 +1,15 @@
 
 ## Front-End and UX Exercise
 
-Copyright 2015, Fauna, Inc. All rights reserved. For general instructions, see [here](https://github.com/faunadb/exercises/blob/master/README.md).
+Copyright 2015, Fauna, Inc. All rights reserved. For general instructions, see [here](https://github.com/fauna/exercises/blob/master/README.md).
 
 ### Responsive Visualization
 
-Consider the following dataset provided by the USDA ([Excel format](https://raw.githubusercontent.com/faunadb/exercises/master/visualization/importedfoodsbycountry2015.xls) / [HTML format](https://raw.githubusercontent.com/faunadb/exercises/master/visualization/importedfoodsbycountry2015.tar.gz)) of food import quantities to the United States by year, category, and origin.
+Consider the following dataset provided by the USDA ([Excel format](https://raw.githubusercontent.com/fauna/exercises/master/visualization/importedfoodsbycountry2015.xls) / [HTML format](https://raw.githubusercontent.com/fauna/exercises/master/visualization/importedfoodsbycountry2015.tar.gz)) of food import quantities to the United States by year, category, and origin.
 
 One way to visualize this data might be:
 
-<img src="https://raw.githubusercontent.com/faunadb/exercises/master/visualization/visualization.jpg" width="50%">
+<img src="https://raw.githubusercontent.com/fauna/exercises/master/visualization/visualization.jpg" width="50%">
 
 But this way is terrible.
 


### PR DESCRIPTION
Updates GitHub links to point at new repo location.

Part of https://github.com/fauna/sales-engineering/issues/525.